### PR TITLE
Fix frontend refresh after balance and transaction sync

### DIFF
--- a/frontend/src/components/WiseManagement.tsx
+++ b/frontend/src/components/WiseManagement.tsx
@@ -387,23 +387,32 @@ const WiseManagement: React.FC = () => {
     const fetchLatestBalances = async () => {
         setBalancesLoading(true);
         setBalancesError(null);
+        setBalances([]); // 清空旧数据，防止误导
+        message.loading({ content: '正在同步并刷新余额数据，请稍候...', key: 'wise-balance-sync', duration: 0 });
         const start = Date.now();
+        let retry = 0;
         try {
             // 先同步到数据库
             const syncRes = await api.post('/wise/sync-balances');
             if (!syncRes.data.success) {
-                message.error(syncRes.data.message || '同步数据库失败');
+                message.error({ content: syncRes.data.message || '同步数据库失败', key: 'wise-balance-sync' });
                 setBalancesLoading(false);
                 return;
             }
-            // 再查数据库最新数据
-            const res = await api.get('/wise/stored-balances');
+            // 再查数据库最新数据，重试最多3次
+            let res;
+            while (retry < 3) {
+                await new Promise(res => setTimeout(res, 1000)); // 每次延迟1秒
+                res = await api.get('/wise/stored-balances');
+                if (res.data?.data && res.data.data.length > 0) break;
+                retry++;
+            }
             setBalances(res.data?.data || res.data || []);
             setBalanceLoadTime(Date.now() - start);
-            message.success(`同步并获取到 ${res.data.count || 0} 条余额记录`);
+            message.success({ content: `同步并获取到 ${res.data.count || 0} 条余额记录`, key: 'wise-balance-sync' });
         } catch (e: any) {
             setBalancesError(e.response?.data?.detail || '获取余额失败');
-            message.error(`同步或获取余额失败: ${e.response?.data?.detail || e.message}`);
+            message.error({ content: `同步或获取余额失败: ${e.response?.data?.detail || e.message}`, key: 'wise-balance-sync' });
         } finally {
             setBalancesLoading(false);
         }
@@ -413,16 +422,20 @@ const WiseManagement: React.FC = () => {
     const fetchLatestTransactions = async () => {
         setTransactionsLoading(true);
         setTransactionsError(null);
+        setTransactions([]); // 清空旧数据，防止误导
+        message.loading({ content: '正在同步并刷新交易记录，请稍候...', key: 'wise-tx-sync', duration: 0 });
         const start = Date.now();
+        let retry = 0;
         try {
             // 先同步到数据库，带上天数参数
             const syncRes = await api.post('/wise/sync-transactions', { days: transactionDays });
             if (!syncRes.data.success) {
-                message.error(syncRes.data.message || '同步交易记录到数据库失败');
+                message.error({ content: syncRes.data.message || '同步交易记录到数据库失败', key: 'wise-tx-sync' });
                 setTransactionsLoading(false);
                 return;
             }
-            // 再查数据库最新数据
+            // 再查数据库最新数据，重试最多3次
+            let res;
             const params: any = { limit: 100 };
             if (transactionDays) {
                 const endDate = new Date();
@@ -431,13 +444,18 @@ const WiseManagement: React.FC = () => {
                 params.from_date = startDate.toISOString().split('T')[0];
                 params.to_date = endDate.toISOString().split('T')[0];
             }
-            const res = await api.get('/wise/stored-transactions', { params });
+            while (retry < 3) {
+                await new Promise(res => setTimeout(res, 1000)); // 每次延迟1秒
+                res = await api.get('/wise/stored-transactions', { params });
+                if (res.data?.data && res.data.data.length > 0) break;
+                retry++;
+            }
             setTransactions(res.data?.data || res.data || []);
             setTransactionsLoadTime(Date.now() - start);
-            message.success(`同步并获取到 ${res.data.count || 0} 条交易记录`);
+            message.success({ content: `同步并获取到 ${res.data.count || 0} 条交易记录`, key: 'wise-tx-sync' });
         } catch (e: any) {
             setTransactionsError(e.response?.data?.detail || '获取交易记录失败');
-            message.error(`同步或获取交易记录失败: ${e.response?.data?.detail || e.message}`);
+            message.error({ content: `同步或获取交易记录失败: ${e.response?.data?.detail || e.message}`, key: 'wise-tx-sync' });
         } finally {
             setTransactionsLoading(false);
         }


### PR DESCRIPTION
Add loading indicators and retry logic to Wise sync to ensure frontend auto-refreshes with latest data.

The previous implementation sometimes failed to display updated Wise balance/transaction data immediately after sync, requiring a manual page refresh, likely due to backend write delays. This change adds a loading state and retries fetching the data up to 3 times after a successful sync, ensuring the UI reflects the latest database state automatically.

---

[Open in Web](https://www.cursor.com/agents?id=bc-7c6c9510-c72a-4552-9e6d-92e2011d616e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7c6c9510-c72a-4552-9e6d-92e2011d616e)